### PR TITLE
refactor: Update settings.gradle.kts for build system refactor

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,80 +1,74 @@
-@file:Suppress("UnstableApiUsage")
-
-// ===== AOSP-Re:Genesis - SETTINGS =====
-// The pluginManagement block MUST be the first block in the file.
-// It defines the versions for all plugins used in the build.
+enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
+enableFeaturePreview("STABLE_CONFIGURATION_CACHE")
 
 pluginManagement {
     repositories {
         gradlePluginPortal()
         google()
         mavenCentral()
+        maven { url = uri("https://maven.lsposed.org/releases") }
+        maven { url = uri("https://s01.oss.sonatype.org/content/repositories/releases/") }
+        maven { url = uri("https://s01.oss.sonatype.org/content/groups/public/") }
     }
-
-    buildscript {
-        repositories {
-            google()
-            mavenCentral()
-        }
-        dependencies {
-
-        }
-    }
-
     plugins {
-        id("com.android.application") version "9.0.0-alpha02" apply false
-        id("com.android.library") version "9.0.0-alpha02" apply false
+        id("com.android.application") version "9.0.0-alpha05" apply false
+        id("com.android.library") version "9.0.0-alpha05" apply false
         id("org.jetbrains.kotlin.android") version "2.2.20" apply false
-        id("org.jetbrains.kotlin.plugin.compose") version "2.2.20" apply false
+        id("org.jetbrains.kotlin.jvm") version "2.2.20" apply false
         id("com.google.devtools.ksp") version "2.2.20-2.0.3" apply false
+        id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
+        id("com.google.gms.google-services") version "4.4.3" apply false
+        id("com.google.android.libraries.mapsplatform.secrets-gradle-plugin") version ("2.0.1") apply false
+        id("org.lsposed.lsparanoid") version ("1.0.0") apply false
+        id("com.google.firebase.crashlytics") version "3.0.1" apply false
+        id("org.openapi.generator") version "7.1.0" apply false
+        id("org.jetbrains.kotlin.plugin.compose") version "2.2.20" apply false
     }
 }
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention")
+}
 
-// Manages dependency repositories for all modules.
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
         google()
-        mavenCentral() // Simplified JitPack declaration
-        // Custom repositories for specific libraries
+        mavenCentral()
+        maven { url = uri("https://maven.lsposed.org/releases") }
+        maven { url = uri("https://api.xposed.info/") }
+        maven { url = uri("https://jitpack.io") }
         maven { url = uri("https://androidx.dev/storage/compose-compiler/repository/") }
         maven { url = uri("https://maven.pkg.jetbrains.space/public/p/compose/dev") }
         maven { url = uri("https://s01.oss.sonatype.org/content/repositories/releases/") }
         maven { url = uri("https://s01.oss.sonatype.org/content/groups/public/") }
     }
 
-
-// Enable modern Gradle features for performance and reliability.
-    enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
-    enableFeaturePreview("STABLE_CONFIGURATION_CACHE")
-
-    rootProject.name = "ReGenesis"
-
-// ===== MODULE INCLUSION =====
-    include(
-        ":app",
-        ":core-module",
-        ":feature-module",
-        ":datavein-oracle-native",
-        ":oracle-drive-integration",
-        ":secure-comm",
-        ":sandbox-ui",
-        ":collab-canvas",
-        ":colorblendr",
-        ":romtools",
-        ":module-a",
-        ":module-b",
-        ":module-c",
-        ":module-d",
-        ":module-e",
-        ":module-f",
-        ":benchmark",
-        ":screenshot-tests",
-        ":jvm-test",
-        ":list",
-        ":utilities"
-    )
-    includeBuild("build-logic")
-    rootProject.name = "build-logic"
-
 }
+
+rootProject.name = "ReGenesis"
+
+include(
+    ":app",
+    ":core-module",
+    ":feature-module",
+    ":datavein-oracle-native",
+    ":oracle-drive-integration",
+    ":secure-comm",
+    ":sandbox-ui",
+    ":collab-canvas",
+    ":colorblendr",
+    ":romtools",
+    ":module-a",
+    ":module-b",
+    ":module-c",
+    ":module-d",
+    ":module-e",
+    ":module-f",
+    ":benchmark",
+    ":screenshot-tests",
+    ":jvm-test",
+    ":list",
+    ":utilities"
+)
+
+includeBuild("build-logic")


### PR DESCRIPTION
This commit updates the `settings.gradle.kts` file with new plugin versions and repository configurations as part of a larger build system refactoring.

This is a partial change as instructed by the user, due to tool failures that prevented a complete refactoring of the toolchain configuration. The core build logic issues related to the Java toolchain and JVM vendor will be tackled in a future voyage.

Key changes in this commit:
- Android Gradle Plugin version updated to `9.0.0-alpha05`.
- New Maven repositories added for LSposed and Xposed.
- The `org.gradle.toolchains.foojay-resolver-convention` plugin is now applied.


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
